### PR TITLE
Hyperapp#2 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "babel-jest": "^22.4.3",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-env": "^1.6.1",
-    "hyperapp": "^1.2.5",
+    "hyperapp": "^2.0.0",
     "jest": "^22.4.3",
     "prettier": "^1.11.1",
     "rollup": "^0.57.1",
@@ -56,6 +56,6 @@
     "typescript": "2.8.1"
   },
   "peerDependencies": {
-    "hyperapp": "1.2.5"
+    "hyperapp": "2.0.0"
   }
 }

--- a/src/Link.js
+++ b/src/Link.js
@@ -1,47 +1,27 @@
-import { h } from "hyperapp"
+import { h } from 'hyperapp'
+import { location } from './location'
 
-function getOrigin(loc) {
-  return loc.protocol + "//" + loc.hostname + (loc.port ? ":" + loc.port : "")
-}
-
-function isExternal(anchorElement) {
-  // Location.origin and HTMLAnchorElement.origin are not
-  // supported by IE and Safari.
-  return getOrigin(location) !== getOrigin(anchorElement)
-}
-
-export function Link(props, children) {
-  return function(state, actions) {
-    var to = props.to
-    var location = state.location
-    var onclick = props.onclick
-    delete props.to
-    delete props.location
-
-    props.href = to
-    props.onclick = function(e) {
-      if (onclick) {
-        onclick(e)
-      }
-      if (
-        e.defaultPrevented ||
-        e.button !== 0 ||
-        e.altKey ||
-        e.metaKey ||
-        e.ctrlKey ||
-        e.shiftKey ||
-        props.target === "_blank" ||
-        isExternal(e.currentTarget)
-      ) {
-      } else {
-        e.preventDefault()
-
-        if (to !== location.pathname) {
-          history.pushState(location.pathname, "", to)
-        }
-      }
-    }
-
-    return h("a", props, children)
+function onClick(state, link, e){
+  if(
+    e.defaultPrevented ||
+    e.button !== 0 ||
+    e.altKey ||
+    e.metaKey ||
+    e.ctrlKey ||
+    e.shiftKey ||
+    e.target.getAttribute("target") === "_blank" ||
+    link.href === state.location.pathname
+  ){
+    return state
+  } else {
+    e.preventDefault()
+    return location(state, link.href)
   }
+}
+
+export function Link(props, childrens){
+  props.onClick = props.onClick || [ onClick, props ]
+  props.href = props.to
+  delete props.to
+  return h('a', props, childrens)
 }

--- a/src/Redirect.js
+++ b/src/Redirect.js
@@ -1,6 +1,0 @@
-export function Redirect(props) {
-  return function(state, actions) {
-    var location = state.location
-    history.replaceState(props.from || location.pathname, "", props.to)
-  }
-}

--- a/src/Route.js
+++ b/src/Route.js
@@ -1,18 +1,23 @@
-import { parseRoute } from "./parseRoute"
+import { Switch } from './Switch'
+import { parseRoute } from './parseRoute'
 
-export function Route(props) {
-  return function(state, actions) {
-    var location = state.location
-    var match = parseRoute(props.path, location.pathname, {
-      exact: !props.parent
-    })
-
-    return (
-      match &&
-      props.render({
-        match: match,
-        location: location
+export function Route(props, childrens){
+  var location = props.location
+  var path = props.path || ''
+  var render = props.render || Switch
+  var match = parseRoute(path, location.pathname, {
+    exact: !props.parent
+  })
+  return (match && render(
+    function(){
+      var args = Array.prototype.slice.call(arguments, 0)
+      args[0] = Object.assign({}, args[0], {
+        location: location,
+        path: path + args[0].path || '',
       })
-    )
-  }
+      return Route.apply(this, args)
+    },
+    Object.assign({}, props, { match: match, location: location } ),
+    childrens)
+  )
 }

--- a/src/Switch.js
+++ b/src/Switch.js
@@ -1,12 +1,3 @@
-export function Switch(props, children) {
-  return function(state, actions) {
-    var child,
-      i = 0
-    while (
-      !(child = children[i] && children[i](state, actions)) &&
-      i < children.length
-    )
-      i++
-    return child
-  }
+export function Switch(props, childrens){
+  return childrens[0]
 }

--- a/src/history.js
+++ b/src/history.js
@@ -1,0 +1,5 @@
+export function history(location){
+  if(location && window.location.pathname !== location.pathname){
+    window.history.pushState(location, '', location.pathname)
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-export { Link } from "./Link"
-export { Route } from "./Route"
-export { Switch } from "./Switch"
-export { Redirect } from "./Redirect"
-export { location } from "./location"
+export { location } from './location'
+export { history } from './history'
+export { Switch } from './Switch'
+export { Route } from './Route'
+export { Link } from './Link'

--- a/src/location.js
+++ b/src/location.js
@@ -1,51 +1,10 @@
-function wrapHistory(keys) {
-  return keys.reduce(function(next, key) {
-    var fn = history[key]
-
-    history[key] = function(data, title, url) {
-      fn.call(this, data, title, url)
-      dispatchEvent(new CustomEvent("pushstate", { detail: data }))
+export function location(state, path){
+  return Object.assign({}, state, {
+    location: {
+      pathname: path || window.location.pathname,
+      previous: state && state.location
+        ? state.location.pathname
+        : window.location.pathname
     }
-
-    return function() {
-      history[key] = fn
-      next && next()
-    }
-  }, null)
-}
-
-export var location = {
-  state: {
-    pathname: window.location.pathname,
-    previous: window.location.pathname
-  },
-  actions: {
-    go: function(pathname) {
-      history.pushState(null, "", pathname)
-    },
-    set: function(data) {
-      return data
-    }
-  },
-  subscribe: function(actions) {
-    function handleLocationChange(e) {
-      actions.set({
-        pathname: window.location.pathname,
-        previous: e.detail
-          ? (window.location.previous = e.detail)
-          : window.location.previous
-      })
-    }
-
-    var unwrap = wrapHistory(["pushState", "replaceState"])
-
-    addEventListener("pushstate", handleLocationChange)
-    addEventListener("popstate", handleLocationChange)
-
-    return function() {
-      removeEventListener("pushstate", handleLocationChange)
-      removeEventListener("popstate", handleLocationChange)
-      unwrap()
-    }
-  }
+  })
 }


### PR DESCRIPTION
### Hyperapp#2 support

Implemented with state-first in mind, simplicity and consistency to hav#1 router
![peek 2018-12-22 11-49](https://user-images.githubusercontent.com/6243887/50372998-dbcd7880-05e0-11e9-92f6-554ca7cd3c7c.gif)

Working example:
```jsx
import { app, h } from 'hyperapp'
import { Link, Route, location, history } from '@hyperapp/router'

const About = () =>
  <div>About</div>

const Home = () =>
  <div>Home</div>

const Topic = (TopicRoute, { match }) =>
  <h3>{match.params.topicId}</h3>

const TopicsView = (TopicsRoute, { match }) => (
  <div key="topics">
    <h2>Topics</h2>
    <ul>
      <li><Link to={`${match.url}/components`}>Components</Link></li>
      <li><Link to={`${match.url}/single-state-tree`}>Single State Tree</Link></li>
      <li><Link to={`${match.url}/routing`}>Routing</Link></li>
    </ul>
    {match.isExact && <h3>Please select a topic.</h3>}
    <TopicsRoute parent path='/:topicId' render={ Topic } />
  </div>
)

document.addEventListener('DOMContentLoaded', () =>
  app({
    init: location,
    view: state => <div>
      <ul>
        <li><Link to="/">Home</Link></li>
        <li><Link to="/about">About</Link></li>
        <li><Link to="/topics">Topics</Link></li>
      </ul>
      <hr />
      <Route location={ state.location } render={ Route => [
        <Route path="/" render={ () => Home() } />,
        <Route path="/about" render={ () => About() } />,
        <Route parent path="/topics" render={ TopicsView } />
      ]} />
    </div>,
    subscriptions: state => {
      // if you want to expose location to window.history
      history(state.location)
      return []
    },
    container: document.body
  })
)
```
Please let me know if you need more examples
----
What left to do: 
- validate 'isExternal' (origin) link 
- update tests
- update README