### PR TITLE
Fix render type of RouteProps.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { VNode } from "hyperapp";
+import { Component, VNode } from "hyperapp";
 
 /** Link */
 interface LinkProps {
@@ -23,7 +23,7 @@ interface RouteProps<P> {
   parent?: boolean;
   path?: string;
   location?: Location;
-  render: (props: RenderProps<P>) => VNode<RenderProps<P>>;
+  render: Component<RenderProps<P>>;
 }
 
 export function Route<P>(


### PR DESCRIPTION
Nice to meet you.

If I used Hyperapp v1 in TypeScript, I corrected it because Route can not interpret types well.

render seems to assume a function that returns VNode, but I think it would be better to receive Component more widely, but would you suggest it?

Now
``` Hoge.tsx
export const Hoge = (): VNode<RenderProps<{}>> => {
  return ( ... )
}
```
``` index.tsx
 <Route path="/something" render={Hoge}/>
```

But I want to use
``` Hoge.tsx
export const Hoge: Component<RenderProps<{}>> = () => {
  return ( ... )
}
```


Thank you

Hyperapp 1.2.5
TypeScript 3.1.4